### PR TITLE
[vnet] Add a test case to run wr_arp test with VNET config

### DIFF
--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -1,3 +1,5 @@
+from tests.arp.args.wr_arp_args import add_wr_arp_args
+
 def pytest_addoption(parser):
     """
     Adds pytest options that are used by VxLAN tests
@@ -70,3 +72,5 @@ def pytest_addoption(parser):
         type=int,
         help="Highest expected src port for VXLAN UPD packet"
     )
+
+    add_wr_arp_args(parser)

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -12,6 +12,8 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses, change_mac_
                                                 copy_arp_responder_py, copy_ptftests_directory
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 
+import tests.arp.test_wr_arp as test_wr_arp
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -95,14 +97,14 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, minigraph_facts, vnet_config
 
     return minigraph_facts
 
-@pytest.fixture(params=["Disabled", "Enabled", "Cleanup"])
-def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, vnet_test_params, vnet_config):
+@pytest.fixture(params=["Disabled", "Enabled", "WR_ARP", "Cleanup"])
+def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, ptfhost, vnet_test_params, vnet_config, creds):
     """
     Paramterized fixture that tests the Disabled, Enabled, and Cleanup configs for VxLAN
 
     Args:
         setup: Pytest fixture that provides access to minigraph facts
-        request: Contains the parameter (Disabled, Enabled, or Cleanup) for the current test iteration
+        request: Contains the parameter (Disabled, Enabled, WR_ARP, or Cleanup) for the current test iteration
         duthost: DUT host object
 
     Returns:
@@ -135,8 +137,11 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, vnet_test_para
         cleanup_vnet_routes(duthost, vnet_config)
         cleanup_dut_vnets(duthost, setup, vnet_config)
         cleanup_vxlan_tunnels(duthost, vnet_test_params)
-    return vxlan_enabled, request.param
+    elif request.param == "WR_ARP":
+        testWrArp = test_wr_arp.TestWrArp()
+        test_wr_arp.TestWrArp.testWrArp(testWrArp, request, duthost, ptfhost, creds)
 
+    return vxlan_enabled, request.param
 
 def test_vnet_vxlan(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhost, vnet_test_params, creds):
     """


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To add new VNET test case to run wr_arp test with VNET config.
Recently support of multiple VxLAN mappers was added which allows to create both VRF and VLAN mappers for 1 tunnel.
It was added to have wr_arp scenario working together with VNET config.
This new test case is indented to verify such flow.

#### How did you do it?
Add new VNET test case to run wr_arp test with VNET config

#### How did you verify/test it?
Ran VNET test.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
T0
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A